### PR TITLE
Use lookup value for front end, so it is mapped to E Team field corre…

### DIFF
--- a/expense-authorization/src/API/EMBC.ExpenseAuthorization.Api/ETeam/ETeamSoapService.cs
+++ b/expense-authorization/src/API/EMBC.ExpenseAuthorization.Api/ETeam/ETeamSoapService.cs
@@ -40,7 +40,7 @@ namespace EMBC.ExpenseAuthorization.Api.ETeam
 
             IList<LookupValue> values = resourceTypeValues
                 .Where(_ => _.Value != null && _.Value.StartsWith(ExpenditureAuthorizationResourceTypePrefix))
-                .Select(_ => new LookupValue { Id = _.Id, Value = _.Value.Substring(ExpenditureAuthorizationResourceTypePrefix.Length)})
+                .Select(_ => new LookupValue { Id = _.Value, Value = _.Value.Substring(ExpenditureAuthorizationResourceTypePrefix.Length)})
                 .ToList();
 
             return values;


### PR DESCRIPTION
Use the original full text of the resource type lookup as the 'Id' for the front end.