### PR TITLE
disable certificate validation

### DIFF
--- a/expense-authorization/src/API/EMBC.ExpenseAuthorization.Api/Email/EmailSender.cs
+++ b/expense-authorization/src/API/EMBC.ExpenseAuthorization.Api/Email/EmailSender.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
 using Microsoft.Extensions.Logging;
@@ -100,6 +101,9 @@ namespace EMBC.ExpenseAuthorization.Api.Email
             {
                 try
                 {
+                    // ignore SSL errors :-(
+                    client.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => true;
+
                     _logger.LogTrace("Connecting to SMTP server using SSL, {SmtpServer}:{Port}", settings.SmtpServer, settings.Port);
                     await client.ConnectAsync(settings.SmtpServer, settings.Port, settings.Ssl);
 


### PR DESCRIPTION
This PR configures the SMTP client to ignore any SSL errors, unfortunately.